### PR TITLE
UIテキストとアプリ名の更新

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <meta name="theme-color" content="#4a6cf7">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-    <meta name="apple-mobile-web-app-title" content="AI画像生成">
+    <meta name="apple-mobile-web-app-title" content="ImageCraft">
     <link rel="apple-touch-icon" href="./images/icons/apple-touch-icon-180x180.png">
     <!-- iPhone用のアイコン -->
     <link rel="apple-touch-icon" sizes="120x120" href="./images/icons/icon-120x120.png">
@@ -24,7 +24,7 @@
     <div class="container">
         <header>
             <h1>ImageCraft AI</h1>
-            <p class="app-description">OpenAIのGPT-Image-1 APIを使用してテキストプロンプトから画像を生成します</p>
+            <p class="app-description">gpt-image-1 APIでテキストプロンプトから画像を生成</p>
         </header>
 
         <main>
@@ -133,7 +133,7 @@
         </main>
 
         <footer>
-            <p>画像はOpenAI APIを使用して生成されています。モデル: gpt-image-1</p>
+            <p><strong>ImageCraft AI © 2025 | Created by A_1_6</strong></p>
         </footer>
     </div>
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "AI画像生成ツール",
-  "short_name": "AI画像生成",
-  "description": "OpenAI APIを使用してテキストプロンプトから画像を生成するアプリ",
+  "name": "ImageCraft",
+  "short_name": "ImageCraft",
+  "description": "gpt-image-1 APIでテキストプロンプトから画像を生成するアプリ",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#f8f9fa",


### PR DESCRIPTION
## 変更内容

3つの重要な修正を実施しました：

### 1. 説明文の簡略化
上部の説明文を：
- Before: "OpenAIのGPT-Image-1 APIを使用してテキストプロンプトから画像を生成します"
- After: "gpt-image-1 APIでテキストプロンプトから画像を生成"

### 2. フッターテキストの更新
下部のフッターを：
- Before: "画像はOpenAI APIを使用して生成されています。モデル: gpt-image-1"
- After: "**ImageCraft AI © 2025 | Created by A_1_6**"

### 3. PWAアプリ名の変更
ホーム画面に追加時の表示名を：
- Before: "AI画像生成"
- After: "ImageCraft"

manifest.jsonの name と short_name を更新しています。

## 影響範囲
- index.html の2ヶ所（説明文、フッター）
- manifest.json の2ヶ所（name、short_name）
- PWA対応のmeta tag（apple-mobile-web-app-title）

## テスト項目
- [ ] デスクトップブラウザでのUI表示確認
- [ ] iPhoneでのPWA動作確認（ホーム画面追加時のアプリ名）
- [ ] アプリ全体の動作確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated app branding and descriptive text to "ImageCraft" across the interface and metadata.
  - Simplified and revised descriptive text for clarity.
  - Updated footer to display a copyright notice.
- **Chores**
  - Refreshed manifest metadata to reflect new app name and description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->